### PR TITLE
Fix GitHub Pages module MIME type loading

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  base: "/",
+});


### PR DESCRIPTION
This fixes the production site failing to boot because the browser was attempting to load `/src/main.tsx` directly and receiving an invalid module MIME type.

I added a root `vite.config.ts` with the React plugin and an explicit `base: "/"` so the GitHub Pages deployment consistently serves the built `dist` module assets referenced by production `index.html`, instead of raw source module paths.

This is intentionally minimal and scoped to build/deploy behavior only; no runtime app logic changed.