### PR TITLE
Fix deploy permissions for GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
The site is still serving a broken publish because the deploy workflow cannot push the built  output to  (403 from github-actions bot). That leaves stale content with  in production.

This adds explicit workflow job permissions:
- 

With this permission,  can push the built artifacts to , so Pages serves the bundled JS modules correctly.